### PR TITLE
Use official Debian boxes

### DIFF
--- a/testing-roles-rolespec-vagrant/Vagrantfile
+++ b/testing-roles-rolespec-vagrant/Vagrantfile
@@ -12,9 +12,8 @@ NETWORK  = "192.168.50."
 NETMASK  = "255.255.255.0"
 
 # Default Virtualbox .box
- # Source: https://github.com/ginas/vagrant-debian-wheezy-64
-BOX       = 'debian-wheezy-amd64-netinst'
-BOXES_URL = 'https://dl.dropboxusercontent.com/u/55426468/20140317'
+# See: https://wiki.debian.org/Teams/Cloud/VagrantBaseBoxes
+BOX               = 'debian/jessie64'
 
 HOSTS = {
    "test1" => [NETWORK+"10", RAM, GUI, BOX],
@@ -42,9 +41,9 @@ Vagrant.configure(2) do |config|
     ipaddr, ram, gui, box = cfg
 
     config.vm.define name do |machine|
-      machine.vm.box     = box
-      machine.vm.box_url = BOXES_URL + box + '.box'
+      machine.vm.box   = box
       machine.vm.guest = :debian
+
       machine.vm.provider "virtualbox" do |vbox|
         vbox.gui    = gui
         vbox.memory = ram

--- a/vagrant-ansible-single-machine/Vagrantfile
+++ b/vagrant-ansible-single-machine/Vagrantfile
@@ -13,9 +13,8 @@ NETWORK           = "192.168.50."
 NETMASK           = "255.255.255.0"
 
 # Default Virtualbox .box
-# Source: https://github.com/ginas/vagrant-debian-wheezy-64
-BOX               = 'debian-wheezy-amd64-netinst'
-BOX_URL           = 'https://dl.dropboxusercontent.com/u/55426468/20140317/debian-wheezy-amd64-netinst.box'
+# See: https://wiki.debian.org/Teams/Cloud/VagrantBaseBoxes
+BOX               = 'debian/jessie64'
 
 # Ansible configuration
 ANSIBLE_INVENTORY = "my-static-vagrant-inventory"
@@ -41,9 +40,7 @@ end
 
 Vagrant.configure(2) do |config|
 
-  config.vm.box     = BOX
-  config.vm.box_url = BOX_URL
-
+  config.vm.box   = BOX
   config.vm.guest = :debian
 
   config.vm.provider "virtualbox" do |vbox|

--- a/vagrant-multi-machine/Vagrantfile
+++ b/vagrant-multi-machine/Vagrantfile
@@ -13,9 +13,8 @@ NETWORK           = "192.168.50."
 NETMASK           = "255.255.255.0"
 
 # Default Virtualbox .box
-# Source: https://github.com/ginas/vagrant-debian-wheezy-64
-BOX               = 'debian-wheezy-amd64-netinst'
-BOX_URL           = 'https://dl.dropboxusercontent.com/u/55426468/20140317/debian-wheezy-amd64-netinst.box'
+# See: https://wiki.debian.org/Teams/Cloud/VagrantBaseBoxes
+BOX               = 'debian/jessie64'
 
 
 HOSTS = {
@@ -32,9 +31,9 @@ Vagrant.configure(2) do |config|
     ipaddr, ram, gui, box = cfg
 
     config.vm.define name do |machine|
-      machine.vm.box     = box
-      machine.vm.box_url = BOX_URL
+      machine.vm.box   = box
       machine.vm.guest = :debian
+
       machine.vm.provider "virtualbox" do |vbox|
         vbox.gui    = gui
         vbox.memory = ram

--- a/webhost-gitusers-dokuwiki/Vagrantfile
+++ b/webhost-gitusers-dokuwiki/Vagrantfile
@@ -13,9 +13,8 @@ NETWORK           = "192.168.50."
 NETMASK           = "255.255.255.0"
 
 # Default Virtualbox .box
-# Source: https://github.com/ginas/vagrant-debian-wheezy-64
-BOX               = 'debian-wheezy-amd64-netinst'
-BOX_URL           = 'https://dl.dropboxusercontent.com/u/55426468/20140317/debian-wheezy-amd64-netinst.box'
+# See: https://wiki.debian.org/Teams/Cloud/VagrantBaseBoxes
+BOX               = 'debian/jessie64'
 
 
 HOSTS = {
@@ -32,8 +31,8 @@ Vagrant.configure(2) do |config|
 
     config.vm.define name do |machine|
       machine.vm.box     = box
-      machine.vm.box_url = BOX_URL
       machine.vm.guest = :debian
+
       machine.vm.provider "virtualbox" do |vbox|
         vbox.gui    = gui
         vbox.memory = ram


### PR DESCRIPTION
Replace Dropbox(?!) URLs with official [Debian boxes](https://atlas.hashicorp.com/debian/boxes/jessie64) hosted by Hashicorp. Also use Debian Jessie instead of Wheezy boxes.