### PR TITLE
Disable SSH host key checking

### DIFF
--- a/debops-bootstrap/bootstrap-debops.yml
+++ b/debops-bootstrap/bootstrap-debops.yml
@@ -31,6 +31,13 @@
         group: 'vagrant'
         mode: '0600'
 
+    - name: Disable strict SSH host key check
+      ini_file:
+        dest: '{{ debops_project_name }}/.debops.cfg'
+        section: 'ansible defaults'
+        option: 'host_key_checking'
+        value: 'False'
+
     - name: Upload Ansible inventory
       copy:
         src: '.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory'


### PR DESCRIPTION
The `Vagrantfile` already defines `ansible.host_key_checking = "false"` so that we can successfully connect to the bootstrapped VM. Make the same for DebOps, so that it will accept the host key of the involved VM(s). Should be safe, as this playbook is meant to be run within Vagrant only.